### PR TITLE
41_GitHubActionsの解説_CD環境構築の課題提出

### DIFF
--- a/.github/workflows/terraform-cicd.yml
+++ b/.github/workflows/terraform-cicd.yml
@@ -81,7 +81,7 @@ jobs:
           # 人間用のplanテキスト
           terraform show -no-color tfplan > plan.txt
 
-      # ✅ planが成功した時だけ成果物をアップロード
+      # ✅ planが成功した時だけ成果物アップロード
       - uses: actions/upload-artifact@v4
         if: success()
         with:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -53,7 +53,7 @@ jobs:
       - run: terraform validate -no-color
       - run: terraform test -no-color
 
-      # ← pipefail版（失敗時に壊れた tfplan を残さない）
+      # ← pipefail版（失敗時に壊れた tfplan を残さな）
       - name: terraform plan (detailed-exitcode, pipefail)
         id: tfplan
         run: |

--- a/chapter0/modules/cloudwatch/main.tf
+++ b/chapter0/modules/cloudwatch/main.tf
@@ -4,7 +4,7 @@ resource "aws_sns_topic" "alarm_topic" {
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_alarm" {
   alarm_name          = "${var.name_prefix}-CPUUtilizationAlarm"
-  alarm_description   = "CPU使用率が0.02%以上でアラーム（本番Applyテスト）"
+  alarm_description   = "CPU使用率が0.02%以上でアラーム"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
   metric_name         = "CPUUtilization"


### PR DESCRIPTION
## 実装内容
41_GitHubActionsの解説_CD環境構築の課題提出
差分pushでplanが走ります。
プルリクエストのmergeでapply実行します。

## 動作確認
### ①差分pushでplanが走ります。
<img width="1342" height="641" alt="スクリーンショット 2025-11-29 21 32 21" src="https://github.com/user-attachments/assets/9232c502-4a18-4e8d-a579-f30b3c76a877" />

### ②プルリクエストのmergeでapply実行します。
<img width="1391" height="671" alt="スクリーンショット 2025-11-29 21 30 50" src="https://github.com/user-attachments/assets/76d4b511-45de-42d5-baf0-123f192d3e3d" />
<img width="1350" height="674" alt="スクリーンショット 2025-11-29 21 31 32" src="https://github.com/user-attachments/assets/c44682f2-e24b-4db6-ae3e-5255228ad8a0" />
https://github.com/MihoDaijo/aws-study/pull/29/commits/a0be5b3e86126239a1d23f02aec1ee70cc7a1fef
https://github.com/MihoDaijo/aws-study/actions/runs/19783581747/job/56687018545

ワークフロー（.github/workflows/*.yml）https://github.com/MihoDaijo/aws-study/pull/9/files
と GitHub OIDC 用の Terraform（chapter0/iam_github_oidc.tf）が追加、PR 時の plan / main push の apply 分離が実装済み。
実行ログ（ URL）
https://github.com/MihoDaijo/aws-study/actions/runs/19783581747/job/56687002827
https://github.com/MihoDaijo/aws-study/actions/runs/19783581747/job/56687018545

## 工夫した点・学んだこと
iamロールの信頼ポリシーの設定、プルリクエストのmergeでapplyがなかなか成功せず苦労しました。
また、terraform destroyでロールを削除してしまい、terraformで自動化すべきとこや手動の設定について考えるきっかけになりました。